### PR TITLE
ci(wasm): fix branch ref

### DIFF
--- a/.github/workflows/ci-wrapper-wasm.yml
+++ b/.github/workflows/ci-wrapper-wasm.yml
@@ -57,7 +57,7 @@ jobs:
     name: Publish unstable package release
     needs: build_test
     runs-on: ubuntu-latest
-    if: github.ref == 'master'
+    if: github.ref == 'refs/head/master'
     defaults:
       run:
         working-directory: ./main/wrappers/wasm


### PR DESCRIPTION
Minor fix for unstable package publishing in referencing the master branch