### PR TITLE
ci(wasm): add nodejs setup step

### DIFF
--- a/.github/workflows/ci-wrapper-wasm.yml
+++ b/.github/workflows/ci-wrapper-wasm.yml
@@ -84,6 +84,13 @@ jobs:
           toolchain: stable
           override: true
 
+      # Required for publishing NPM package
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+          registry-url: "https://registry.npmjs.org"
+
       - name: Run yarn install
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
Adds nodejs setup step to enable publishing the package to NPM