### PR TITLE
chore: pin github actions versions

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -29,7 +29,7 @@ jobs:
           path: main # TODO remove once temp build step below is removed
 
       - name: Setup stable rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:
           profile: minimal
           toolchain: stable
@@ -37,7 +37,7 @@ jobs:
 
       # Note some of the rules we use for fmt and clippy are only available with the nightly toolchain
       - name: Setup nightly rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:
           profile: minimal
           toolchain: nightly
@@ -45,7 +45,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run cargo format
-        uses: marcopolo/cargo@master
+        uses: marcopolo/cargo@a527bf4d534717ff4424a84446c5d710f8833139 # pin@master
         with:
           command: fmt
           toolchain: nightly # Note some of the rules we use for fmt are only available with the nightly toolchain
@@ -53,7 +53,7 @@ jobs:
           args: --all -- --check
 
       - name: Run cargo clippy
-        uses: marcopolo/cargo@master
+        uses: marcopolo/cargo@a527bf4d534717ff4424a84446c5d710f8833139 # pin@master
         with:
           command: clippy
           toolchain: nightly # Note some of the rules we use for clippy are only available with the nightly toolchain
@@ -61,29 +61,29 @@ jobs:
           args: -- -D warnings
 
       - name: Run cargo check
-        uses: marcopolo/cargo@master
+        uses: marcopolo/cargo@a527bf4d534717ff4424a84446c5d710f8833139 # pin@master
         with:
           command: check
           toolchain: stable
           working-directory: main # TODO remove once temp build step below is removed, revert to actions-rs/cargo action
 
       - name: Run cargo audit
-        uses: marcopolo/cargo@master
+        uses: marcopolo/cargo@a527bf4d534717ff4424a84446c5d710f8833139 # pin@master
         with:
           command: audit
           toolchain: stable
           working-directory: main # TODO remove once temp build step below is removed, revert to actions-rs/cargo action
 
       - name: Run cargo test
-        uses: marcopolo/cargo@master
+        uses: marcopolo/cargo@a527bf4d534717ff4424a84446c5d710f8833139 # pin@master
         with:
           command: test
           toolchain: stable
           working-directory: main # TODO remove once temp build step below is removed, revert to actions-rs/cargo action
-          args: "--release"
+          args: '--release'
 
       - name: Run cargo build
-        uses: marcopolo/cargo@master
+        uses: marcopolo/cargo@a527bf4d534717ff4424a84446c5d710f8833139 # pin@master
         with:
           command: build
           toolchain: stable

--- a/.github/workflows/ci-wrapper-c.yml
+++ b/.github/workflows/ci-wrapper-c.yml
@@ -32,7 +32,7 @@ jobs:
           path: main # TODO remove once temp build step below is removed
 
       - name: Setup rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:
           toolchain: nightly # Note this has to be nightly because the header generation step does not work on stable
           override: true

--- a/.github/workflows/ci-wrapper-wasm.yml
+++ b/.github/workflows/ci-wrapper-wasm.yml
@@ -32,7 +32,7 @@ jobs:
           path: main # TODO remove once temp build step below is removed
 
       - name: Setup rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:
           profile: minimal
           toolchain: stable
@@ -78,7 +78,7 @@ jobs:
           path: main # TODO remove once temp build step below is removed
 
       - name: Setup rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:
           profile: minimal
           toolchain: stable
@@ -89,7 +89,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16.x
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Run yarn install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/github_backup.yaml
+++ b/.github/workflows/github_backup.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # pin @v1.6.1
         with:
           aws-region: ap-southeast-2
           role-to-assume: arn:aws:iam::817632051851:role/oidc-github-actions-mattrglobal-global
@@ -22,7 +22,7 @@ jobs:
           role-session-name: GithubActions
 
       - name: Backing up this repo to AWS S3
-        uses: peter-evans/s3-backup@v1
+        uses: peter-evans/s3-backup@4f39c7dab63c7666d6ba6722d7966e7d0655583c # pin @v1.1.0
         env:
           AWS_REGION: ${{ env.AWS_REGION }}
           ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
As part of the preparation for the Trail of Bits audit we are pinning all non GitHub owned actions.

## Description

Pinning:
- configure-aws-credentials to v1.6.1 with this [commit](https://github.com/aws-actions/configure-aws-credentials/commit/05b148adc31e091bafbaf404f745055d4d3bc9d2)
- s3-backup to v1.1.0 with this [commit](https://github.com/peter-evans/s3-backup/commit/4f39c7dab63c7666d6ba6722d7966e7d0655583c)
- toolchain to v1.0.6 with this [commit](https://github.com/actions-rs/toolchain/commit/b2417cde72dcf67f306c0ae8e0828a81bf0b189f)
- cargo to master with this [commit](https://github.com/MarcoPolo/cargo/commit/a527bf4d534717ff4424a84446c5d710f8833139)

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

[DXM-854](https://mattrglobal.atlassian.net/jira/software/c/projects/DXM/boards/49?modal=detail&selectedIssue=DXM-854)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)