### PR TITLE
feat(wasm): switch to default allocator

### DIFF
--- a/wrappers/wasm/Cargo.toml
+++ b/wrappers/wasm/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [features]
-default = ["wee_alloc"]
 console_error = ["console_error_panic_hook"]
 
 [dependencies]
@@ -21,7 +20,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.1.3"
 wasm-bindgen = "0.2.74"
 wasm-bindgen-futures = "0.4.18"
-wee_alloc = { version = "0.4.2", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [profile.release]


### PR DESCRIPTION
As flagged by dependabot, it seems `wee_alloc` [is not maintained](https://github.com/rustwasm/wee_alloc/issues/107). So switching to default std allocator. As of now, there is no production-ready alternative for a small code size allocator as `wee_alloc`, we need to keep an eye on such allocator and make it available as an addiotional allocator in our crate. 