### PR TITLE
chore: bump blstrs and related deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ __private_generator_api = []
 
 [dependencies]
 digest = "0.9"
-ff = "0.11.0"
-group = "0.11.0"
+ff = "0.12.0"
+group = "0.12.0"
 rand = { version = "0.8", features = ["getrandom"] }
 getrandom = { version = "0.2", optional = true, features = ["js"] }
 rand_core = "0.6"
-pairing = "0.21.0"
+pairing = "0.22.0"
 # TODO note prior to crate publication this dependency MUST be shifted to a published version of blstrs
-blstrs = { version = "0.4.2", path = "./../blstrs" }
+blstrs = { version = "0.6.1", path = "./../blstrs" }
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.4"
 zeroize = { version  ="1.3", features = ["zeroize_derive"] }


### PR DESCRIPTION
Dependent on [blstrs upstream sync PR ](https://github.com/mattrglobal/blstrs/pull/10)