### PR TITLE
fix(wasm): sign "is not a function" error fix

### DIFF
--- a/wrappers/wasm/src/bbs/api.rs
+++ b/wrappers/wasm/src/bbs/api.rs
@@ -407,7 +407,7 @@ macro_rules! bbs_wrapper_api_generator {
 }
 
 bbs_wrapper_api_generator!(
-    bbs_bls12_381_sha2_56_sign,
+    bbs_bls12_381_sha_256_sign,
     bls12_381_sha_256_sign,
     bbs_bls12_381_sha_256_verify,
     bls12_381_sha_256_verify,


### PR DESCRIPTION
Just fixing a small typo that resulted to the error when using sign.