### PR TITLE
feat(ci): disable rust incremental builds from CI

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Test after generating fixtures
         uses: marcopolo/cargo@a527bf4d534717ff4424a84446c5d710f8833139 # pin@master
         env:
+          # Disabling incremental builds as this feature isn't used in this GH job and with it enabled an overhead is in-cured see https://github.com/dtolnay/rust-toolchain/issues/26 for more information
           CARGO_INCREMENTAL: 0
         with:
           command: test


### PR DESCRIPTION
As CI jobs are independent and run from scratch, it's not useful to have incremental builds. [Here](https://github.com/dtolnay/rust-toolchain/issues/26) is one of the discussion in Rust community doing this.