### PR TITLE
fix(rn): cjs output

### DIFF
--- a/wrappers/react-native/package.json
+++ b/wrappers/react-native/package.json
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit && yarn example tsc --noEmit",
     "build:all": "yarn build && yarn build:ios && yarn build:android",
     "build": "rm -rf lib/ && yarn build:cjs && yarn build:esm && yarn build:types",
-    "build:cjs": "tsc --pretty --outDir lib/commonjs",
+    "build:cjs": "tsc --pretty --module commonjs --outDir lib/commonjs",
     "build:esm": "tsc --pretty --module ES2015 --outDir lib/module",
     "build:types": "tsc --pretty --declaration --emitDeclarationOnly --outDir lib/typescript",
     "build:ios": "./scripts/build-ios.sh",


### PR DESCRIPTION
Updates the CJS build to output CJS rather than the default output module configured in tsconfig.json