### PR TITLE
fix: add utility funcs to rn

### DIFF
--- a/wrappers/react-native/src/utilities.ts
+++ b/wrappers/react-native/src/utilities.ts
@@ -71,6 +71,6 @@ export const convertRevealMessageArrayToRevealMap = <E>(
   return messages.reduce(
     (map: Record<number, RevealMessage<E>>, message: RevealMessage<E>, i: number) =>
       message.reveal ? { ...map, [i]: message } : map,
-    messages
+    {}
   );
 };


### PR DESCRIPTION
This adds `convertToRevealMessageArray` and `convertRevealMessageArrayToRevealMap` to the react-native utilities module. This is already supported by [the wasm wrapper](https://github.com/mattrglobal/pairing_crypto/blob/549d12b31803db50bc4729ac28f45d96f95ff560/wrappers/wasm/src/js/index.js#L240-L243).

Co-authored-by: Frederick Cai <frederick.cai@mattr.global>