### PR TITLE
fix: typo in utilities

### DIFF
--- a/wrappers/react-native/src/utilities.ts
+++ b/wrappers/react-native/src/utilities.ts
@@ -58,7 +58,7 @@ interface RevealMessage<E> {
   reveal: boolean;
 }
 
-export const convertToRevealMessageArray = <E>(messages: E[], revealedIndicies: number[]): RevealMessage<E>[] => {
+export const convertToRevealMessagesArray = <E>(messages: E[], revealedIndicies: number[]): RevealMessage<E>[] => {
   return messages.map((value: E, i: number) => ({
     reveal: revealedIndicies.includes(i),
     value,


### PR DESCRIPTION
I just noticed I spelt a utility function wrong. This fixes the error

<img width="760" alt="image" src="https://github.com/mattrglobal/pairing_crypto/assets/108311641/9224bb25-6b06-4c7b-83bb-f869c8505db1">
