### PR TITLE
ci: use node 18 in actions

### DIFF
--- a/.github/workflows/ci-detox-android.yml
+++ b/.github/workflows/ci-detox-android.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Download Android Libraries

--- a/.github/workflows/ci-detox-ios.yml
+++ b/.github/workflows/ci-detox-ios.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Download iOS Libraries

--- a/.github/workflows/ci-wrapper-rn.yml
+++ b/.github/workflows/ci-wrapper-rn.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Install Dependencies
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Run yarn install
@@ -115,7 +115,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Run yarn install

--- a/.github/workflows/ci-wrapper-wasm.yml
+++ b/.github/workflows/ci-wrapper-wasm.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: "https://registry.npmjs.org"
 
       - name: Run yarn install
@@ -130,7 +130,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: "https://registry.npmjs.org"
 
       - name: Run yarn install


### PR DESCRIPTION
Converts all GitHub actions to use Node 18.x (up from 16.x)