### PR TITLE
Key representation conversion utils

### DIFF
--- a/src/common/key_pair.rs
+++ b/src/common/key_pair.rs
@@ -179,6 +179,9 @@ macro_rules! bbs_bls_key_pair_impl {
             /// Number of bytes needed to represent the public key in compressed
             /// form.
             pub const SIZE_BYTES: usize = $octet_point_length;
+            /// Number of bytes needed to represent the public key in uncompressed
+            /// form.
+            pub const SIZE_BYTES_UNCOMPRESSED: usize = 2 * Self::SIZE_BYTES;
 
             /// Check if the `PublicKey` is valid.
             pub fn is_valid(&self) -> Choice {
@@ -193,12 +196,25 @@ macro_rules! bbs_bls_key_pair_impl {
                 self.0.to_affine().to_compressed()
             }
 
+            /// Get the G2 representation in affine, uncompressed and big-endian
+            /// form of PublicKey.
+            pub fn to_octets_uncompressed(&self) -> [u8; Self::SIZE_BYTES_UNCOMPRESSED] {
+                self.0.to_uncompressed()
+            }
+
             /// Convert a vector of bytes of big-endian representation of the
             /// public key.
             pub fn from_vec(bytes: &Vec<u8>) -> Result<Self, Error> {
-                match vec_to_byte_array::<{ Self::SIZE_BYTES }>(bytes) {
-                    Ok(result) => Self::from_octets(&result),
-                    Err(e) => Err(e),
+                match bytes.len() {
+                    Self::SIZE_BYTES => { 
+                        let byte_array = vec_to_byte_array::<{ Self::SIZE_BYTES }>(bytes)?;
+                        Self::from_octets(&byte_array)
+                    },
+                    Self::SIZE_BYTES_UNCOMPRESSED => {  
+                        let byte_array = vec_to_byte_array::<{ Self::SIZE_BYTES_UNCOMPRESSED }>(bytes)?;
+                        Self::from_octets_uncompressed(&byte_array)
+                    },
+                    _ => Err(Error::BadEncoding)
                 }
             }
 
@@ -214,6 +230,34 @@ macro_rules! bbs_bls_key_pair_impl {
                     Ok(result.unwrap())
                 } else {
                     Err(Error::BadEncoding)
+                }
+            }
+
+            /// Convert from G2 point in affine, uncompressed and big-endian form
+            /// to PublicKey.
+            pub fn from_octets_uncompressed(bytes: &[u8; Self::SIZE_BYTES_UNCOMPRESSED]) -> Result<Self, Error> {
+                let result = $point_projective_type::from_uncompressed(bytes);
+
+                if result.is_some().unwrap_u8() == 1u8 {
+                    Ok(Self(result.unwrap()))
+                } else {
+                    Err(Error::BadEncoding)
+                }
+            }
+
+            /// Convert a public key from compressed to uncompressed representation
+            pub fn compressed_to_uncompressed(bytes: &Vec<u8>) -> Result<[u8; Self::SIZE_BYTES_UNCOMPRESSED], Error> {
+                match Self::from_vec(bytes) {
+                    Ok(public_key) => Ok(Self::to_octets_uncompressed(&public_key)),
+                    Err(e) => Err(e)
+                }
+            }
+
+            /// Convert a public key from uncompressed to compressed representation
+            pub fn uncompressed_to_compressed(bytes: &Vec<u8>) -> Result<[u8; Self::SIZE_BYTES], Error> {
+                match Self::from_vec(bytes) {
+                    Ok(public_key) => Ok(Self::to_octets(&public_key)),
+                    Err(e) => Err(e)
                 }
             }
         }

--- a/src/curves/bls12_381.rs
+++ b/src/curves/bls12_381.rs
@@ -1,4 +1,4 @@
-pub use blstrs::{Bls12 as pairing_engine, *};
+pub use blstrs::*;
 
 /// Number of bytes to store a scalar.
 pub(crate) const OCTET_SCALAR_LENGTH: usize = 32;

--- a/wrappers/wasm/__tests__/bbs/bls12381/keyGen.spec.ts
+++ b/wrappers/wasm/__tests__/bbs/bls12381/keyGen.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import { bbs } from "../../../lib";
+import { utilities } from "../../../lib";
 
 describe("bbs", () => {
   describe("bls12381_shake256", () => {
@@ -61,6 +62,49 @@ describe("bbs", () => {
           expect(result.secretKey as Uint8Array).toEqual(value.secretKey);
           expect(result.publicKey).toEqual(value.publicKey);
         });
+
+        it("should be able to map a compressed public key to an uncompressed representation", async () => {
+          const compressed_keypair = await bbs.bls12381_shake256.generateKeyPair({
+            ikm: value.ikm,
+            keyInfo: value.keyInfo,
+          });
+
+          const uncompressed_keypair = await bbs.bls12381_shake256.generateKeyPairUncompressed({
+            ikm: value.ikm,
+            keyInfo: value.keyInfo,
+          });
+
+          const uncompressed_from_compressed_pk = await utilities.compressedToUncompressedPublicKey(
+            compressed_keypair.publicKey
+          );
+
+          const compressed_from_uncompressed_pk = await utilities.uncompressedToCompressedPublicKey(
+            uncompressed_keypair.publicKey
+          );
+
+          expect(compressed_keypair.publicKey).toBeDefined();
+          expect(compressed_keypair.secretKey).toBeDefined();
+
+          expect(uncompressed_keypair.publicKey).toBeDefined();
+          expect(uncompressed_keypair.secretKey).toBeDefined();
+          expect(uncompressed_keypair.publicKey?.length as number).toEqual(
+            bbs.bls12381_shake256.PUBLIC_KEY_LENGTH * 2
+          )
+
+          expect(uncompressed_from_compressed_pk).toBeDefined();
+          expect(uncompressed_from_compressed_pk?.length as number).toEqual(
+            bbs.bls12381_shake256.PUBLIC_KEY_LENGTH * 2
+          )
+
+          expect(uncompressed_keypair.publicKey).toEqual(uncompressed_from_compressed_pk)
+
+          expect(compressed_from_uncompressed_pk).toBeDefined();
+          expect(compressed_from_uncompressed_pk?.length as number).toEqual(
+            bbs.bls12381_shake256.PUBLIC_KEY_LENGTH
+          )
+
+          expect(compressed_keypair.publicKey).toEqual(compressed_from_uncompressed_pk)
+        });
       });
 
       it("should be able to generate a key pair from random", async () => {
@@ -73,6 +117,7 @@ describe("bbs", () => {
         );
         expect(result.publicKey.length).toEqual(bbs.bls12381_shake256.PUBLIC_KEY_LENGTH);
       });
+
     });
   });
 });

--- a/wrappers/wasm/src/js/index.d.ts
+++ b/wrappers/wasm/src/js/index.d.ts
@@ -47,6 +47,9 @@ export namespace bbs {
     function generateKeyPair(
       request?: KeyGenerationRequest
     ): Promise<Required<KeyPair>>;
+    function generateKeyPairUncompressed(
+      request?: KeyGenerationRequest
+    ): Promise<Required<KeyPair>>;
     function sign(request: BbsSignRequest): Promise<Uint8Array>;
     function verify(request: BbsVerifyRequest): Promise<BbsVerifyResult>;
     function deriveProof(request: BbsDeriveProofRequest): Promise<Uint8Array>;
@@ -61,6 +64,9 @@ export namespace bbs {
     const SIGNATURE_LENGTH = 80;
 
     function generateKeyPair(
+      request?: KeyGenerationRequest
+    ): Promise<Required<KeyPair>>;
+    function generateKeyPairUncompressed(
       request?: KeyGenerationRequest
     ): Promise<Required<KeyPair>>;
     function sign(request: BbsSignRequest): Promise<Uint8Array>;
@@ -107,4 +113,12 @@ export namespace utilities {
   function convertRevealMessageArrayToRevealMap(
     messages: { value: Uint8Array; reveal: boolean }[]
   ): { [key: number]: Uint8Array };
+
+  function compressedToUncompressedPublicKey(
+    request?: Uint8Array
+  ): Promise<Uint8Array>;
+
+  function uncompressedToCompressedPublicKey(
+    request?: Uint8Array
+  ): Promise<Uint8Array>;
 }

--- a/wrappers/wasm/src/js/index.js
+++ b/wrappers/wasm/src/js/index.js
@@ -70,6 +70,33 @@ const bbs_bls12_381_generate_key_pair = async (request) => {
     };
 };
 
+const bbs_bls12_381_generate_key_pair_uncompressed = async (request) => {
+    await initialize();
+    var result = await throwErrorOnRejectedPromise(
+        wasm.bbs_bls12_381_generate_key_pair_uncompressed(request ?? {})
+    );
+    return {
+        secretKey: new Uint8Array(result.secretKey),
+        publicKey: new Uint8Array(result.publicKey),
+    };
+}
+
+const bbs_bls12_381_compressed_to_uncompressed_public_key = async (request) => {
+    await initialize();
+    var result = await throwErrorOnRejectedPromise(
+        wasm.bbs_bls12_381_compressed_to_uncompressed_public_key(request ?? {})
+    );
+    return new Uint8Array(result);
+}
+
+const bbs_bls12_381_uncompressed_to_compressed_public_key = async (request) => {
+    await initialize();
+    var result = await throwErrorOnRejectedPromise(
+        wasm.bbs_bls12_381_uncompressed_to_compressed_public_key(request ?? {})
+    );
+    return new Uint8Array(result);
+}
+
 const bbs_bls12_381_sha_256_sign = async (request) => {
     await initialize();
     return new Uint8Array(await throwErrorOnRejectedPromise(wasm.bbs_bls12_381_sha_256_sign(request)));
@@ -198,6 +225,7 @@ module.exports.bbs = {
         SIGNATURE_LENGTH: DEFAULT_BLS12381_BBS_SIGNATURE_LENGTH,
 
         generateKeyPair: bbs_bls12_381_generate_key_pair,
+        generateKeyPairUncompressed: bbs_bls12_381_generate_key_pair_uncompressed,
         sign: bbs_bls12_381_sha_256_sign,
         verify: bbs_bls12_381_sha_256_verify,
         deriveProof: bbs_bls12_381_sha_256_proof_gen,
@@ -209,6 +237,7 @@ module.exports.bbs = {
         SIGNATURE_LENGTH: DEFAULT_BLS12381_BBS_SIGNATURE_LENGTH,
 
         generateKeyPair: bbs_bls12_381_generate_key_pair,
+        generateKeyPairUncompressed: bbs_bls12_381_generate_key_pair_uncompressed,
         sign: bbs_bls12_381_shake_256_sign,
         verify: bbs_bls12_381_shake_256_verify,
         deriveProof: bbs_bls12_381_shake_256_proof_gen,
@@ -239,5 +268,7 @@ module.exports.bbs_bound = {
 
 module.exports.utilities = {
     convertToRevealMessageArray,
-    convertRevealMessageArrayToRevealMap
+    convertRevealMessageArrayToRevealMap,
+    compressedToUncompressedPublicKey: bbs_bls12_381_compressed_to_uncompressed_public_key,
+    uncompressedToCompressedPublicKey: bbs_bls12_381_uncompressed_to_compressed_public_key,
 }


### PR DESCRIPTION
Add utilities to transform a public key from an uncompressed to a compressed representation and vice versa.

Expose the funcionality to WASM.