### PR TITLE
chore: use http for blstrs git dependency

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -16,12 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      # - name: Setup SSH Agent
-      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-      #   with:
-      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - name: Setup stable rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
+      # - name: Setup SSH Agent
+      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Setup stable rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6

--- a/.github/workflows/ci-detox-android.yml
+++ b/.github/workflows/ci-detox-android.yml
@@ -16,12 +16,6 @@
 #       - name: Checkout
 #         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-#       # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-#       - name: Setup SSH Agent
-#         uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-#         with:
-#           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
 #       - name: Setup rust toolchain
 #         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
 #         with:

--- a/.github/workflows/ci-detox-ios.yml
+++ b/.github/workflows/ci-detox-ios.yml
@@ -17,12 +17,6 @@
 #       - name: Checkout
 #         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-#       # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-#       - name: Setup SSH Agent
-#         uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-#         with:
-#           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
 #       - name: Setup rust toolchain
 #         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
 #         with:

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:

--- a/.github/workflows/ci-obj-c.yml
+++ b/.github/workflows/ci-obj-c.yml
@@ -19,12 +19,6 @@
 #       - name: Checkout
 #         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-#       # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-#       - name: Setup SSH Agent
-#         uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-#         with:
-#           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
 #       - name: Build binary
 #         run: ./scripts/update-libraries.sh
 #         shell: bash

--- a/.github/workflows/ci-wrapper-c.yml
+++ b/.github/workflows/ci-wrapper-c.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:

--- a/.github/workflows/ci-wrapper-rn.yml
+++ b/.github/workflows/ci-wrapper-rn.yml
@@ -49,11 +49,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
+      # - name: Setup SSH Agent
+      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6

--- a/.github/workflows/ci-wrapper-rn.yml
+++ b/.github/workflows/ci-wrapper-rn.yml
@@ -49,12 +49,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      # - name: Setup SSH Agent
-      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-      #   with:
-      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:
@@ -104,12 +98,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
-
-      # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6

--- a/.github/workflows/ci-wrapper-wasm.yml
+++ b/.github/workflows/ci-wrapper-wasm.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      # - name: Setup SSH Agent
-      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-      #   with:
-      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:
@@ -61,12 +55,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
-
-      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      # - name: Setup SSH Agent
-      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-      #   with:
-      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
@@ -115,12 +103,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
-
-      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      # - name: Setup SSH Agent
-      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-      #   with:
-      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6

--- a/.github/workflows/ci-wrapper-wasm.yml
+++ b/.github/workflows/ci-wrapper-wasm.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
+      # - name: Setup SSH Agent
+      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
@@ -62,11 +62,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
+      # - name: Setup SSH Agent
+      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
@@ -116,11 +116,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # pin@v3.5.1
 
-      # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      # # Needed to resolve any private git based dependencies like https://github.com/mattrglobal/blstrs
+      # - name: Setup SSH Agent
+      #   uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # pin@v0.7.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rand = { version = "0.8", features = ["getrandom"] }
 getrandom = { version = "0.2", optional = true, features = ["js"] }
 rand_core = "0.6"
 pairing = "0.22.0"
-blstrs = { git = "https://git@github.com/mattrglobal/blstrs", rev = "a0cb960", version = "0.6.1" }
+blstrs = { git = "https://github.com/mattrglobal/blstrs.git", rev = "a0cb960", version = "0.6.1" }
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.4"
 zeroize = { version  ="1.3", features = ["zeroize_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rand = { version = "0.8", features = ["getrandom"] }
 getrandom = { version = "0.2", optional = true, features = ["js"] }
 rand_core = "0.6"
 pairing = "0.22.0"
-blstrs = { git = "ssh://git@github.com/mattrglobal/blstrs", rev = "a0cb960", version = "0.6.1" }
+blstrs = { git = "https://git@github.com/mattrglobal/blstrs", rev = "a0cb960", version = "0.6.1" }
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.4"
 zeroize = { version  ="1.3", features = ["zeroize_derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -175,7 +175,7 @@ unknown-git = "deny"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = [ "ssh://git@github.com/mattrglobal/blstrs" ]
+allow-git = [ "https://git@github.com/mattrglobal/blstrs" ]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for

--- a/deny.toml
+++ b/deny.toml
@@ -175,7 +175,7 @@ unknown-git = "deny"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = [ "https://git@github.com/mattrglobal/blstrs" ]
+allow-git = [ "https://github.com/mattrglobal/blstrs.git" ]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for

--- a/tools/bbs-fixtures-generator/Cargo.toml
+++ b/tools/bbs-fixtures-generator/Cargo.toml
@@ -24,4 +24,4 @@ sha2 = { version = "0.9", default-features = false }
 sha3 = "0.9"
 hkdf = "0.11"
 digest = "0.9"
-blstrs = { git = "ssh://git@github.com/mattrglobal/blstrs", rev = "a0cb960", version = "0.6.1" }
+blstrs = { git = "https://git@github.com/mattrglobal/blstrs", rev = "a0cb960", version = "0.6.1" }

--- a/tools/bbs-fixtures-generator/Cargo.toml
+++ b/tools/bbs-fixtures-generator/Cargo.toml
@@ -24,4 +24,4 @@ sha2 = { version = "0.9", default-features = false }
 sha3 = "0.9"
 hkdf = "0.11"
 digest = "0.9"
-blstrs = { git = "https://git@github.com/mattrglobal/blstrs", rev = "a0cb960", version = "0.6.1" }
+blstrs = { git = "https://github.com/mattrglobal/blstrs.git", rev = "a0cb960", version = "0.6.1" }


### PR DESCRIPTION
Fix up pipeline remove `ssh` requirement for git dependency and use `https` since the repository is public.

Alternatively we can update the CI secret to include the SSH key.