### PR TITLE
ci: allow unicode 3.0 licence

### DIFF
--- a/.github/workflows/ci-detox-android.yml
+++ b/.github/workflows/ci-detox-android.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: "adopt"
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -33,7 +33,7 @@ jobs:
           distribution: "adopt"
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,7 @@ allow = [
     "Apache-2.0",
     "BSD-3-Clause",
     "Unicode-DFS-2016",
+    "Unicode-3.0"
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.


### PR DESCRIPTION
Fixes build problems:
* The _cargo deny_ licence checker was failing because Unicode 3.0 wasn't allowed.
* The versions of cache actions were out of date.

Unicode 3.0 licence approved under [MISD-7610](https://mattrglobal.atlassian.net/servicedesk/customer/portal/4/MISD-7610)