### PR TITLE
chore(deps): bump transitive tmp dependency as resolution

### DIFF
--- a/wrappers/react-native/example/package.json
+++ b/wrappers/react-native/example/package.json
@@ -54,6 +54,7 @@
     "shell-quote": "1.7.3",
     "detox/child-process-promise/cross-spawn": "7.0.6",
     "patch-package/cross-spawn": "7.0.6",
+    "patch-package/tmp": "0.2.5",
     "glob": "9.3.5"
   }
 }

--- a/wrappers/react-native/example/yarn.lock
+++ b/wrappers/react-native/example/yarn.lock
@@ -5195,11 +5195,6 @@ ora@^5.4.1:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
-
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -6274,12 +6269,10 @@ through2@^2.0.1:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+tmp@0.2.5, tmp@^0.0.33:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
+  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
There is an open vulnerability on the [tmp](https://www.npmjs.com/package/tmp) package, which is a transitive dependency of [patch-package](https://www.npmjs.com/package/patch-package): https://github.com/mattrglobal/pairing_crypto/security/dependabot/94

Unfortunately patch-package [did not bump tmp yet](https://github.com/ds300/patch-package/issues/577), they use it at [`"^0.0.33"`](https://github.com/ds300/patch-package/blob/bd2e9a49d884516199079add143c1649541e8efe/package.json#L86C13-L86C20), which means that on `yarn add` yarn will install version 0.0.33 or any later patch release (0.0.34, 0.0.35, etc.), but will not upgrade to 0.2.4, where the vulnerability is fixed.

This is why a resolution is our only option here.