### PR TITLE
chore(deps): bump transitive on-headers dependency as resolution

### DIFF
--- a/wrappers/react-native/package.json
+++ b/wrappers/react-native/package.json
@@ -86,7 +86,8 @@
     "react-native": "*"
   },
   "resolutions": {
-    "semver": "7.5.2"
+    "semver": "7.5.2",
+    "on-headers": "1.1.0"
   },
   "jest": {
     "preset": "react-native",

--- a/wrappers/react-native/yarn.lock
+++ b/wrappers/react-native/yarn.lock
@@ -4638,10 +4638,10 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
-  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+on-headers@1.1.0, on-headers@~1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.1.0.tgz#59da4f91c45f5f989c6e4bcedc5a3b0aed70ff65"
+  integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
Bumping on-headers as resolution to fix security vulnerability: https://github.com/mattrglobal/pairing_crypto/security/dependabot/91