### PR TITLE
fix(react-native-example): patch metro with compatible react-native-community version

### DIFF
--- a/wrappers/react-native/example/package.json
+++ b/wrappers/react-native/example/package.json
@@ -19,9 +19,9 @@
   "devDependencies": {
     "@babel/core": "7.26.10",
     "@babel/runtime": "7.26.10",
-    "@react-native-community/cli": "14.1.2",
-    "@react-native-community/cli-platform-android": "14.1.2",
-    "@react-native-community/cli-platform-ios": "14.1.2",
+    "@react-native-community/cli": "15.1.3",
+    "@react-native-community/cli-platform-android": "15.1.3",
+    "@react-native-community/cli-platform-ios": "15.1.3",
     "@react-native/babel-preset": "0.76.9",
     "@react-native/eslint-config": "0.76.9",
     "@react-native/metro-config": "0.76.9",

--- a/wrappers/react-native/example/package.json
+++ b/wrappers/react-native/example/package.json
@@ -19,9 +19,9 @@
   "devDependencies": {
     "@babel/core": "7.26.10",
     "@babel/runtime": "7.26.10",
-    "@react-native-community/cli": "17.0.1",
-    "@react-native-community/cli-platform-android": "17.0.1",
-    "@react-native-community/cli-platform-ios": "17.0.1",
+    "@react-native-community/cli": "14.1.2",
+    "@react-native-community/cli-platform-android": "14.1.2",
+    "@react-native-community/cli-platform-ios": "14.1.2",
     "@react-native/babel-preset": "0.76.9",
     "@react-native/eslint-config": "0.76.9",
     "@react-native/metro-config": "0.76.9",

--- a/wrappers/react-native/example/yarn.lock
+++ b/wrappers/react-native/example/yarn.lock
@@ -1116,45 +1116,65 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-community/cli-clean@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-14.1.2.tgz#b625ec93f4dbdb48472f102713aa8927cd32cbf0"
-  integrity sha512-33MK2Dt4eTFjE1m8XQL5VcEV4acgdw6XVXaYpe6jd3IKvdmQpYzMM7W4BxMVMjBGmPnzK+6jLsCZmLkeAWpUew==
+"@react-native-community/cli-clean@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-15.1.3.tgz#cc177378d9c903737fbc1f22d7aa712a61d562be"
+  integrity sha512-3s9NGapIkONFoCUN2s77NYI987GPSCdr74rTf0TWyGIDf4vTYgKoWKKR+Ml3VTa1BCj51r4cYuHEKE1pjUSc0w==
   dependencies:
-    "@react-native-community/cli-tools" "14.1.2"
+    "@react-native-community/cli-tools" "15.1.3"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-glob "^3.3.2"
 
-"@react-native-community/cli-config@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-14.1.2.tgz#fbbf4f98f904be19498739f5a984efa37a96cb7c"
-  integrity sha512-UF3UDVn9kl2Zx+NOwwMjzIw7DN1CpG5l9llOelGnyJvcuUsCh62Q8tutJA5icV7qG40kp3//fYKJgjW8o/LUuA==
+"@react-native-community/cli-config-android@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config-android/-/cli-config-android-15.1.3.tgz#c1d91246291c8584ab7bafc63198860d86884f24"
+  integrity sha512-v9okV/WQfMJEWRddI0S6no2v9Lvk54KgFkw1mvMYhJKVqloCNsIWzoqme0u7zIuYSzwsjXUQXVlGiDzbbwdkBw==
   dependencies:
-    "@react-native-community/cli-tools" "14.1.2"
+    "@react-native-community/cli-tools" "15.1.3"
+    chalk "^4.1.2"
+    fast-glob "^3.3.2"
+    fast-xml-parser "^4.4.1"
+
+"@react-native-community/cli-config-apple@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config-apple/-/cli-config-apple-15.1.3.tgz#fa9aab320d6f8fa3319fef9304e442dd11884d58"
+  integrity sha512-Qv6jaEaycv+7s8wR9l9bdpIeSNFCeVANfGCX1x76SgOmGfZNIa7J3l1HaeF/5ktERMYsw/hm4u3rUn4Ks0YV1g==
+  dependencies:
+    "@react-native-community/cli-tools" "15.1.3"
+    chalk "^4.1.2"
+    execa "^5.0.0"
+    fast-glob "^3.3.2"
+
+"@react-native-community/cli-config@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-15.1.3.tgz#bdc12e63ff72963319a527acb313978b37d106c1"
+  integrity sha512-fJ9MrWp+/SszEVg5Wja8A57Whl5EfjRCHWFNkvFBtfjVUfi2hWvSTW3VBxzJuCHnPIIwpQafwjEgOrIRUI8y6w==
+  dependencies:
+    "@react-native-community/cli-tools" "15.1.3"
     chalk "^4.1.2"
     cosmiconfig "^9.0.0"
     deepmerge "^4.3.0"
     fast-glob "^3.3.2"
     joi "^17.2.1"
 
-"@react-native-community/cli-debugger-ui@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-14.1.2.tgz#c18d032a6c8bd646a668f2359f67ee370ae487a0"
-  integrity sha512-FzUoyuKqV890lt4exU/jjRmVzhrPVcWr7rWhWjq0n0IeFO3idvgmTFTM0p9xr6vXRv8aLxoLZcfsRfv6NM+Zag==
+"@react-native-community/cli-debugger-ui@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-15.1.3.tgz#fc8ac730bf1b61e16b2e3910ef654c79726ee654"
+  integrity sha512-m+fb9iAUNb9WiDdokCBLh0InJvollcgAM3gLjCT8DGTP6bH/jxtZ3DszzyIRqN9cMamItVrvDM0vkIg48xK7rQ==
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-14.1.2.tgz#183ce63b3f892e0edebaae355010cb4315590659"
-  integrity sha512-ttY9eAzzp/770SHpnTsT1760k1Wnlaxh9tDi42utF2BFqlN9L5NCl+G2RT2VJEtR+Sf3ZC0cm5G6Z225GIKvpg==
+"@react-native-community/cli-doctor@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-15.1.3.tgz#2a6d103e899773fe738f67d97da0a4f74549eed9"
+  integrity sha512-WC9rawobuITAtJjyZ68E1M0geRt+b9A2CGB354L/tQp+XMKobGGVI4Y0DsattK83Wdg59GPyldE8C0Wevfgm/A==
   dependencies:
-    "@react-native-community/cli-config" "14.1.2"
-    "@react-native-community/cli-platform-android" "14.1.2"
-    "@react-native-community/cli-platform-apple" "14.1.2"
-    "@react-native-community/cli-platform-ios" "14.1.2"
-    "@react-native-community/cli-tools" "14.1.2"
+    "@react-native-community/cli-config" "15.1.3"
+    "@react-native-community/cli-platform-android" "15.1.3"
+    "@react-native-community/cli-platform-apple" "15.1.3"
+    "@react-native-community/cli-platform-ios" "15.1.3"
+    "@react-native-community/cli-tools" "15.1.3"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     deepmerge "^4.3.0"
@@ -1167,44 +1187,42 @@
     wcwidth "^1.0.1"
     yaml "^2.2.1"
 
-"@react-native-community/cli-platform-android@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-14.1.2.tgz#8b0c648103559d31cd0bd53486af014b5e26cabe"
-  integrity sha512-d3jlj9/zPKUyzDZhnInK8jMhfNBIZ9LrIgHllMJmD1LaArhV6ngBIKxTvSLDebLRaxFtrGisONJoV7zI/UFOyw==
+"@react-native-community/cli-platform-android@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-15.1.3.tgz#c10c434ea559414b00ca3297a4aabbbba16647c8"
+  integrity sha512-ZwrBK0UK4DRHoQm2v5m8+PlNHBK5gmibBU6rqNFLo4aZJ2Rufalbv3SF+DukgSyoI9/kI8UVrzSNj17e+HhN5A==
   dependencies:
-    "@react-native-community/cli-tools" "14.1.2"
+    "@react-native-community/cli-config-android" "15.1.3"
+    "@react-native-community/cli-tools" "15.1.3"
     chalk "^4.1.2"
     execa "^5.0.0"
-    fast-glob "^3.3.2"
-    fast-xml-parser "^4.4.1"
     logkitty "^0.7.1"
 
-"@react-native-community/cli-platform-apple@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-14.1.2.tgz#ad163b7efb27a0a3da4fa74992ecb9defe076e48"
-  integrity sha512-0Q+Fsc94WsPvAhAt+Zk2GKMLvXVY5tkmA1sYVHAOmEuJkJU0QkkuviFW4XYChJks+p+J078gHAu2nNfkYvbkNg==
+"@react-native-community/cli-platform-apple@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-15.1.3.tgz#e8cd6d7edad60ee21e38d9c338332645a05d05e3"
+  integrity sha512-awotqCGVcTdeRmTlE3wlsZgNxZUDGojUhPYOVMKejgdCzNM2bvzF8fqhETH2sc64Hbw/tQJg8pYeD4MZR0bHxw==
   dependencies:
-    "@react-native-community/cli-tools" "14.1.2"
+    "@react-native-community/cli-config-apple" "15.1.3"
+    "@react-native-community/cli-tools" "15.1.3"
     chalk "^4.1.2"
     execa "^5.0.0"
-    fast-glob "^3.3.2"
     fast-xml-parser "^4.4.1"
-    ora "^5.4.1"
 
-"@react-native-community/cli-platform-ios@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-14.1.2.tgz#d7d4bba0e8917d9137a3e7e63bfc3cddc5b308dc"
-  integrity sha512-c282Uh02W0i+Ee0P9BA92yb30rw1KQ+5PNQauQEWyRyzaAK2QKODkxZaBro0+1CcVmtBhesO7nvBldEsdgdacQ==
+"@react-native-community/cli-platform-ios@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-15.1.3.tgz#57d119796b2eab49565131cdfefcf22211a8fdad"
+  integrity sha512-DxM8GYkqjrlGuuGiGjrcvUmKC2xv9zDzHbsc4+S160Nn0zbF2OH1DhMlnIuUeCmQnAO6QFMqU99O120iEzCAug==
   dependencies:
-    "@react-native-community/cli-platform-apple" "14.1.2"
+    "@react-native-community/cli-platform-apple" "15.1.3"
 
-"@react-native-community/cli-server-api@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-14.1.2.tgz#64d3c69dbe01eb024011616d147a14c21f37edd1"
-  integrity sha512-VW606gHiAONuyRNAK0vQNKGH5P23Y5PmHRXzZCXkZvb0FVe+CeEKXre3xuWfaG7c+7NUkw7nVJC3/ns0lCxQNw==
+"@react-native-community/cli-server-api@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-15.1.3.tgz#a0da5d36680802f699f6ddea4873048fb57dfa19"
+  integrity sha512-kXZ0evedluLt6flWQiI3JqwnW8rSBspOoQ7JVTQYiG5lDHAeL3Om9PjAyiQBg1EZRMjiWZDV7nDxhR+m+6NX5Q==
   dependencies:
-    "@react-native-community/cli-debugger-ui" "14.1.2"
-    "@react-native-community/cli-tools" "14.1.2"
+    "@react-native-community/cli-debugger-ui" "15.1.3"
+    "@react-native-community/cli-tools" "15.1.3"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.1"
@@ -1213,10 +1231,10 @@
     serve-static "^1.13.1"
     ws "^6.2.3"
 
-"@react-native-community/cli-tools@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-14.1.2.tgz#6a3c063a695e642f84319f56740681cd129005fb"
-  integrity sha512-kBoZw4u6WDIIx1c9Wa3ENVxiDh+VgSH3CztZQKLLL8RZ350vLdLBlW4U8BMChii+/J8wBrXt32bdfANcMJqX+g==
+"@react-native-community/cli-tools@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-15.1.3.tgz#354863cefd8e39e674c072c6b18a1ac4d4497d30"
+  integrity sha512-2RzoUKR+Y03ijBeeSoCSQihyN6dxy3fbHjraO4MheZZUzt/Yd1VMEDd0R5aa6rtiRDoknbHt45RL2GMa8MSaEA==
   dependencies:
     appdirsjs "^1.2.4"
     chalk "^4.1.2"
@@ -1225,29 +1243,30 @@
     mime "^2.4.1"
     open "^6.2.0"
     ora "^5.4.1"
+    prompts "^2.4.2"
     semver "^7.5.2"
     shell-quote "^1.7.3"
     sudo-prompt "^9.0.0"
 
-"@react-native-community/cli-types@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-14.1.2.tgz#8b6cf7968295d3f3a2f5c803eb0df5d9d3922b4f"
-  integrity sha512-CQ5JObrPQg471zB/8nP1VhZJWYfAJGnEh0PBouoYuTlR2J6R4ANjtHiFEEehBoLd2KP+Jbp6jxinMce2NOl4zw==
+"@react-native-community/cli-types@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-15.1.3.tgz#1e6d6cd24e2eba974031fc7553f214b653b1f1b4"
+  integrity sha512-0ZaM8LMsa7z7swBN+ObL2ysc6aA3AdS698Q6uEukym6RyX1uLbiofUdlvFSMpWSEL3D8f9OTymmL4RkCH8k6dw==
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-14.1.2.tgz#2019f4287a6264e54cee83379d15fa1fc60bd51a"
-  integrity sha512-m//tTz77dpX3jY86t/KSfZ4dPKHRr8ObpiSxgEGjVEqoZmStcAcqvZCZMZK00u8aXKt4OKCUmhTc1aDLAPMZxg==
+"@react-native-community/cli@15.1.3":
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-15.1.3.tgz#35c113d19282b8ac22bfa55ac0045fa8d3c04834"
+  integrity sha512-+ih/WYUkJsEV2CMAnOHvVoSIz/Ahg5UJk+sqSIOmY79mWAglQzfLP71o7b0neJCnJWLmWiO6G6/S+kmULefD5g==
   dependencies:
-    "@react-native-community/cli-clean" "14.1.2"
-    "@react-native-community/cli-config" "14.1.2"
-    "@react-native-community/cli-debugger-ui" "14.1.2"
-    "@react-native-community/cli-doctor" "14.1.2"
-    "@react-native-community/cli-server-api" "14.1.2"
-    "@react-native-community/cli-tools" "14.1.2"
-    "@react-native-community/cli-types" "14.1.2"
+    "@react-native-community/cli-clean" "15.1.3"
+    "@react-native-community/cli-config" "15.1.3"
+    "@react-native-community/cli-debugger-ui" "15.1.3"
+    "@react-native-community/cli-doctor" "15.1.3"
+    "@react-native-community/cli-server-api" "15.1.3"
+    "@react-native-community/cli-tools" "15.1.3"
+    "@react-native-community/cli-types" "15.1.3"
     chalk "^4.1.2"
     commander "^9.4.1"
     deepmerge "^4.3.0"

--- a/wrappers/react-native/example/yarn.lock
+++ b/wrappers/react-native/example/yarn.lock
@@ -1116,58 +1116,45 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-community/cli-clean@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-17.0.1.tgz#018ad815a105aa6050c3b593416a7a77e0b7f18e"
-  integrity sha512-iy2GzwaRPlI6c2/TtgmeH5TOaVtVDtcpItVmK8qx5RJoKu6c7Ry+ZI6Nw9LZGucLkB6ItZTMDWTSM8PMhcVpuw==
+"@react-native-community/cli-clean@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-14.1.2.tgz#b625ec93f4dbdb48472f102713aa8927cd32cbf0"
+  integrity sha512-33MK2Dt4eTFjE1m8XQL5VcEV4acgdw6XVXaYpe6jd3IKvdmQpYzMM7W4BxMVMjBGmPnzK+6jLsCZmLkeAWpUew==
   dependencies:
-    "@react-native-community/cli-tools" "17.0.1"
+    "@react-native-community/cli-tools" "14.1.2"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-glob "^3.3.2"
 
-"@react-native-community/cli-config-android@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config-android/-/cli-config-android-17.0.1.tgz#fb399cd06b3a28aa3ea5d30710cf27818a272b34"
-  integrity sha512-Y5kqeu2LoydjJYiucRTNa1HK0aAOix7Uo7b4squxdvOwuYSfzVUsALyCgMTAXkzddpGK6B4xxCl4dYqb1CSPeg==
+"@react-native-community/cli-config@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-14.1.2.tgz#fbbf4f98f904be19498739f5a984efa37a96cb7c"
+  integrity sha512-UF3UDVn9kl2Zx+NOwwMjzIw7DN1CpG5l9llOelGnyJvcuUsCh62Q8tutJA5icV7qG40kp3//fYKJgjW8o/LUuA==
   dependencies:
-    "@react-native-community/cli-tools" "17.0.1"
-    chalk "^4.1.2"
-    fast-glob "^3.3.2"
-    fast-xml-parser "^4.4.1"
-
-"@react-native-community/cli-config-apple@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config-apple/-/cli-config-apple-17.0.1.tgz#0074f80272a1e6c01d7c064481dd0cefb203197e"
-  integrity sha512-byaowz9eai54X9Mqi6djsB30dYyopSOw1SCxb1T1H9x1j4MqKexMxTrGF3oV6D9/RkWbDoT4hG7uh9fP3O9tAg==
-  dependencies:
-    "@react-native-community/cli-tools" "17.0.1"
-    chalk "^4.1.2"
-    execa "^5.0.0"
-    fast-glob "^3.3.2"
-
-"@react-native-community/cli-config@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-17.0.1.tgz#52c8ba995bfdefdef97133df037697efbd562724"
-  integrity sha512-5ZTKflLfmwgm8W0vcMi87mk3EK92uCMIJ/mTCcS46KKMIIpUtQpBxvj1kVy89mCQ8Mgc8C7GRnnrnuubDE6zaw==
-  dependencies:
-    "@react-native-community/cli-tools" "17.0.1"
+    "@react-native-community/cli-tools" "14.1.2"
     chalk "^4.1.2"
     cosmiconfig "^9.0.0"
     deepmerge "^4.3.0"
     fast-glob "^3.3.2"
     joi "^17.2.1"
 
-"@react-native-community/cli-doctor@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-17.0.1.tgz#ca955b6f697eaad2ec8ccad0a76b60b62a7a603c"
-  integrity sha512-cN7C6Fn4hcyitXvnDHVY1YNm23m6Hwqdz+DO3K2xVtKKHuJgEx64ZfeWgo/kHC85dtgj5s9jhitpt1ceu7bx9g==
+"@react-native-community/cli-debugger-ui@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-14.1.2.tgz#c18d032a6c8bd646a668f2359f67ee370ae487a0"
+  integrity sha512-FzUoyuKqV890lt4exU/jjRmVzhrPVcWr7rWhWjq0n0IeFO3idvgmTFTM0p9xr6vXRv8aLxoLZcfsRfv6NM+Zag==
   dependencies:
-    "@react-native-community/cli-config" "17.0.1"
-    "@react-native-community/cli-platform-android" "17.0.1"
-    "@react-native-community/cli-platform-apple" "17.0.1"
-    "@react-native-community/cli-platform-ios" "17.0.1"
-    "@react-native-community/cli-tools" "17.0.1"
+    serve-static "^1.13.1"
+
+"@react-native-community/cli-doctor@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-14.1.2.tgz#183ce63b3f892e0edebaae355010cb4315590659"
+  integrity sha512-ttY9eAzzp/770SHpnTsT1760k1Wnlaxh9tDi42utF2BFqlN9L5NCl+G2RT2VJEtR+Sf3ZC0cm5G6Z225GIKvpg==
+  dependencies:
+    "@react-native-community/cli-config" "14.1.2"
+    "@react-native-community/cli-platform-android" "14.1.2"
+    "@react-native-community/cli-platform-apple" "14.1.2"
+    "@react-native-community/cli-platform-ios" "14.1.2"
+    "@react-native-community/cli-tools" "14.1.2"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     deepmerge "^4.3.0"
@@ -1176,88 +1163,91 @@
     node-stream-zip "^1.9.1"
     ora "^5.4.1"
     semver "^7.5.2"
+    strip-ansi "^5.2.0"
     wcwidth "^1.0.1"
     yaml "^2.2.1"
 
-"@react-native-community/cli-platform-android@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-17.0.1.tgz#a8cbd2b6a9477465502392f6530f8acc0ed8fe1d"
-  integrity sha512-gGKWuIBiw+Ic5gdye5gUO471DMg6a1qK/KFoSaUstivH1UCkbmOMguVfw3pmOteZYwX1R9Vgm8RbwPZBxS6f5Q==
+"@react-native-community/cli-platform-android@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-14.1.2.tgz#8b0c648103559d31cd0bd53486af014b5e26cabe"
+  integrity sha512-d3jlj9/zPKUyzDZhnInK8jMhfNBIZ9LrIgHllMJmD1LaArhV6ngBIKxTvSLDebLRaxFtrGisONJoV7zI/UFOyw==
   dependencies:
-    "@react-native-community/cli-config-android" "17.0.1"
-    "@react-native-community/cli-tools" "17.0.1"
+    "@react-native-community/cli-tools" "14.1.2"
     chalk "^4.1.2"
     execa "^5.0.0"
+    fast-glob "^3.3.2"
+    fast-xml-parser "^4.4.1"
     logkitty "^0.7.1"
 
-"@react-native-community/cli-platform-apple@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-17.0.1.tgz#07881c5f027da8e3dd265fb525fb6a68b321bd77"
-  integrity sha512-+W4b2RBYW8LV/vKW+UoAowlVXBo17Nj8KeqtWPZq8SiXcQoJMZIVwmbceYb00X4h8jg3SEbjNbTHbUbt1jZqOg==
+"@react-native-community/cli-platform-apple@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-14.1.2.tgz#ad163b7efb27a0a3da4fa74992ecb9defe076e48"
+  integrity sha512-0Q+Fsc94WsPvAhAt+Zk2GKMLvXVY5tkmA1sYVHAOmEuJkJU0QkkuviFW4XYChJks+p+J078gHAu2nNfkYvbkNg==
   dependencies:
-    "@react-native-community/cli-config-apple" "17.0.1"
-    "@react-native-community/cli-tools" "17.0.1"
+    "@react-native-community/cli-tools" "14.1.2"
     chalk "^4.1.2"
     execa "^5.0.0"
+    fast-glob "^3.3.2"
     fast-xml-parser "^4.4.1"
+    ora "^5.4.1"
 
-"@react-native-community/cli-platform-ios@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-17.0.1.tgz#63cf2ccb55f8fb2803ce22c19b848b21eb7b5b78"
-  integrity sha512-uRUzwwLnBl2zvLnAzO7oZ5NC/IliSpAJdxrodk/1h2PRxQGxpGxZ4QBChiQBLHmXgqoXPyqALyL54E0UyIo2wg==
+"@react-native-community/cli-platform-ios@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-14.1.2.tgz#d7d4bba0e8917d9137a3e7e63bfc3cddc5b308dc"
+  integrity sha512-c282Uh02W0i+Ee0P9BA92yb30rw1KQ+5PNQauQEWyRyzaAK2QKODkxZaBro0+1CcVmtBhesO7nvBldEsdgdacQ==
   dependencies:
-    "@react-native-community/cli-platform-apple" "17.0.1"
+    "@react-native-community/cli-platform-apple" "14.1.2"
 
-"@react-native-community/cli-server-api@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-17.0.1.tgz#5c64d518bc3c3cad168a23d55e33fff5198f06e8"
-  integrity sha512-29sRkTItEA7eTVkkxZgMbO3iBGH39O+WCHY9E6futDSlDgP5PxQDxjZ/degcB05e3PRM2kyZcimqeiTs+T84pA==
+"@react-native-community/cli-server-api@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-14.1.2.tgz#64d3c69dbe01eb024011616d147a14c21f37edd1"
+  integrity sha512-VW606gHiAONuyRNAK0vQNKGH5P23Y5PmHRXzZCXkZvb0FVe+CeEKXre3xuWfaG7c+7NUkw7nVJC3/ns0lCxQNw==
   dependencies:
-    "@react-native-community/cli-tools" "17.0.1"
-    body-parser "^1.20.3"
+    "@react-native-community/cli-debugger-ui" "14.1.2"
+    "@react-native-community/cli-tools" "14.1.2"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.1"
     nocache "^3.0.1"
-    open "^6.2.0"
     pretty-format "^26.6.2"
     serve-static "^1.13.1"
     ws "^6.2.3"
 
-"@react-native-community/cli-tools@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-17.0.1.tgz#5eb7170e79a49fcf7a0a0a730fd713eb8b631ee9"
-  integrity sha512-q2tjUMQadbikAttPPOkKV69dQz/Ju5xkJIPIU6TaF47jft5s8D9v1jc3R04LMKp+FvIlh4g/+pLvEzcv2b7OFA==
+"@react-native-community/cli-tools@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-14.1.2.tgz#6a3c063a695e642f84319f56740681cd129005fb"
+  integrity sha512-kBoZw4u6WDIIx1c9Wa3ENVxiDh+VgSH3CztZQKLLL8RZ350vLdLBlW4U8BMChii+/J8wBrXt32bdfANcMJqX+g==
   dependencies:
-    "@vscode/sudo-prompt" "^9.0.0"
     appdirsjs "^1.2.4"
     chalk "^4.1.2"
     execa "^5.0.0"
     find-up "^5.0.0"
-    launch-editor "^2.9.1"
     mime "^2.4.1"
+    open "^6.2.0"
     ora "^5.4.1"
-    prompts "^2.4.2"
     semver "^7.5.2"
+    shell-quote "^1.7.3"
+    sudo-prompt "^9.0.0"
 
-"@react-native-community/cli-types@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-17.0.1.tgz#05489bff8eb7a9acd379dccd2e2bc35f54bcd99a"
-  integrity sha512-b/UXRQpt7spcVsGYRCD2TsyNjPhtG4rsE00MmJYTixhqlkoruyzSCSyAPo+aKKdfQwBmqjrTF97q709NgJtOjg==
+"@react-native-community/cli-types@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-14.1.2.tgz#8b6cf7968295d3f3a2f5c803eb0df5d9d3922b4f"
+  integrity sha512-CQ5JObrPQg471zB/8nP1VhZJWYfAJGnEh0PBouoYuTlR2J6R4ANjtHiFEEehBoLd2KP+Jbp6jxinMce2NOl4zw==
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-17.0.1.tgz#603f775690b199e51b44e1df1f51b5809341a6d4"
-  integrity sha512-8U7GmGAGfZBWPwL4rlSy3JZw9/9BIYLE0317yioMfVJ8AeZiy1prDdXawUN1WNSj4MdbQekPhqmbEeEQieFuyA==
+"@react-native-community/cli@14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-14.1.2.tgz#2019f4287a6264e54cee83379d15fa1fc60bd51a"
+  integrity sha512-m//tTz77dpX3jY86t/KSfZ4dPKHRr8ObpiSxgEGjVEqoZmStcAcqvZCZMZK00u8aXKt4OKCUmhTc1aDLAPMZxg==
   dependencies:
-    "@react-native-community/cli-clean" "17.0.1"
-    "@react-native-community/cli-config" "17.0.1"
-    "@react-native-community/cli-doctor" "17.0.1"
-    "@react-native-community/cli-server-api" "17.0.1"
-    "@react-native-community/cli-tools" "17.0.1"
-    "@react-native-community/cli-types" "17.0.1"
+    "@react-native-community/cli-clean" "14.1.2"
+    "@react-native-community/cli-config" "14.1.2"
+    "@react-native-community/cli-debugger-ui" "14.1.2"
+    "@react-native-community/cli-doctor" "14.1.2"
+    "@react-native-community/cli-server-api" "14.1.2"
+    "@react-native-community/cli-tools" "14.1.2"
+    "@react-native-community/cli-types" "14.1.2"
     chalk "^4.1.2"
     commander "^9.4.1"
     deepmerge "^4.3.0"
@@ -1775,11 +1765,6 @@
     "@typescript-eslint/types" "7.18.0"
     eslint-visitor-keys "^3.4.3"
 
-"@vscode/sudo-prompt@^9.0.0":
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/@vscode/sudo-prompt/-/sudo-prompt-9.3.2.tgz#692ba38df40bd3502ccc4e9f099fbbaedbd5f04e"
-  integrity sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==
-
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
@@ -2173,24 +2158,6 @@ bluebird@^3.5.4:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-body-parser@^1.20.3:
-  version "1.20.4"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.4.tgz#f8e20f4d06ca8a50a71ed329c15dccad1cdc547f"
-  integrity sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==
-  dependencies:
-    bytes "~3.1.2"
-    content-type "~1.0.5"
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "~1.2.0"
-    http-errors "~2.0.1"
-    iconv-lite "~0.4.24"
-    on-finished "~2.4.1"
-    qs "~6.14.0"
-    raw-body "~2.5.3"
-    type-is "~1.6.18"
-    unpipe "~1.0.0"
-
 brace-expansion@^1.1.7:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.13.tgz#d37875c01dc9eff988dd49d112a57cb67b54efe6"
@@ -2296,7 +2263,7 @@ bunyan@^2.0.5:
     mv "~2"
     safe-json-stringify "~1"
 
-bytes@3.1.2, bytes@~3.1.2:
+bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
@@ -2582,11 +2549,6 @@ connect@^3.6.5:
     parseurl "~1.3.3"
     utils-merge "1.0.1"
 
-content-type@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
-  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
-
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -2747,7 +2709,7 @@ depd@2.0.0, depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@1.2.0, destroy@~1.2.0:
+destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -3641,13 +3603,6 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
-
-iconv-lite@~0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
@@ -4590,14 +4545,6 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-launch-editor@^2.9.1:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.13.2.tgz#41d51baaf8afb393224b89bd2bcb4e02f2306405"
-  integrity sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==
-  dependencies:
-    picocolors "^1.1.1"
-    shell-quote "^1.8.3"
-
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -4732,11 +4679,6 @@ math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
-
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-  integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
 memoize-one@^5.0.0:
   version "5.2.1"
@@ -4963,7 +4905,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.27, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.27, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -5554,7 +5496,7 @@ pure-rand@^6.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
-qs@6.14.1, qs@~6.14.0:
+qs@6.14.1:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
   integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
@@ -5582,16 +5524,6 @@ range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
-
-raw-body@~2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.3.tgz#11c6650ee770a7de1b494f197927de0c923822e2"
-  integrity sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==
-  dependencies:
-    bytes "~3.1.2"
-    http-errors "~2.0.1"
-    iconv-lite "~0.4.24"
-    unpipe "~1.0.0"
 
 react-devtools-core@^5.3.1:
   version "5.3.2"
@@ -5945,11 +5877,6 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-"safer-buffer@>= 2.1.2 < 3":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
 sanitize-filename@^1.6.1:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.4.tgz#b6b39ebed9bd1a1898b85c5c03089da74590d6f8"
@@ -6080,7 +6007,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.3, shell-quote@^1.6.1, shell-quote@^1.7.2, shell-quote@^1.8.3:
+shell-quote@1.7.3, shell-quote@^1.6.1, shell-quote@^1.7.2, shell-quote@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
@@ -6329,7 +6256,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi@^5.0.0:
+strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -6362,6 +6289,11 @@ strnum@^2.1.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.3.tgz#0119fce02749a11bb126a4d686ac5dbdf6e57586"
   integrity sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==
+
+sudo-prompt@^9.0.0:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-9.2.1.tgz#77efb84309c9ca489527a4e749f287e6bdd52afd"
+  integrity sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -6527,14 +6459,6 @@ type-fest@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
-
-type-is@~1.6.18:
-  version "1.6.18"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
-  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.24"
 
 typed-array-buffer@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Patches incompatible versions `@react-native-community/cli@17.0.1` was added alongside the RN 0.76.9 upgrade, but versions are incompatible. This causes a crash when starting up metro dev server.

```bash
From earlier in the session:
TypeError: Cannot read properties of undefined (reading 'handle')
    at Function.use (/Users/thomas.pearson/code/mattr/pairing_crypto/wrappers/react-native/example/node_modules/connect/index.js:87:21)
    at exports.runServer (/Users/thomas.pearson/code/mattr/pairing_crypto/wrappers/react-native/example/node_modules/metro/src/index.flow.js:146:15)
```


**Fix**
Downgrade to cli@15.1.3 the correct version for RN 0.74 - 0.78 per the official RN templates. cli@16 and 17 were never paired with any stable RN release.

This follows the [recommended versions](https://github.com/react-native-community/cli?tab=readme-ov-file#compatibility) and major version is used in the react-native upgrade helper [template](https://github.com/react-native-community/rn-diff-purge/blob/e27b2248e1fcb8c61f5e65da99839f2d12a1b576/RnDiffApp/package.json#L20-L22).

