### PR TITLE
build(deps): update shell-quote for react-native example app

### DIFF
--- a/wrappers/react-native/example/package.json
+++ b/wrappers/react-native/example/package.json
@@ -54,7 +54,7 @@
   "resolutions": {
     "semver": "7.5.2",
     "json5": "1.0.2",
-    "shell-quote": "1.7.3",
+    "shell-quote": "1.8.4",
     "detox/child-process-promise/cross-spawn": "7.0.6",
     "patch-package/cross-spawn": "7.0.6",
     "patch-package/tmp": "0.2.5",

--- a/wrappers/react-native/example/yarn.lock
+++ b/wrappers/react-native/example/yarn.lock
@@ -6080,10 +6080,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.3, shell-quote@^1.6.1, shell-quote@^1.7.2, shell-quote@^1.8.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
-  integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
+shell-quote@1.8.4, shell-quote@^1.6.1, shell-quote@^1.7.2, shell-quote@^1.8.3:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel-list@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Fixes transitive shell-quote vulnerability (CVE-2026-9277)  for **example** application.
Just bumps the existing shell-quote resolution in example/package.json from 1.7.3 → 1.8.4, which contains the fix.
                                                                                     
`shell-quote@1.7.3` is a transitive dependency pulled in via three paths:                                                      
                                        
- react-native → react-devtools-core → shell-quote                
- detox → shell-quote                                             
- @react-native-community/cli → cli-tools → shell-quote           
                                                                  
It is vulnerable to Arbitrary Command Injection CVE-2026-9277
https://security.snyk.io/vuln/SNYK-JS-SHELLQUOTE-16799355                    
                                                                                                               
                                                            